### PR TITLE
Bug fixes to bootstrap task + splitting out dotfiles portion

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,8 @@ namespace :dotfiles do
     Code.setup
 
     Ruby.setup
+
+    Code.install_gems
   end
 
   task :symlinks do

--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,8 @@ namespace :dotfiles do
     Ruby.setup
 
     Code.install_gems
+
+    Ruby.rvm_warning
   end
 
   task :symlinks do

--- a/Rakefile
+++ b/Rakefile
@@ -6,24 +6,26 @@ namespace :dotfiles do
 
     Homebrew.setup
 
+    Code.setup
+
+    Ruby.setup
+  end
+
+  task :symlinks do
     [Zsh, Vim, Tmux, Tmuxinator, Git].each do |klass|
       klass.set_symlinks
     end
+  end
 
-    Code.setup
-
-    [Homebrew, Zsh, Ruby, Vim].each { |klass| klass.setup }
-
-    Code.install_gems
+  task :plugins do
+    [Zsh, Vim].each { |klass| klass.setup }
   end
 
   task :update do
-    # Github.pull_master
-    #
-    # Homebrew.update
-    #
-    # Ruby.update
-    #
-    # Vim.update
+    Homebrew.update
+
+    Ruby.update
+
+    Vim.update
   end
 end

--- a/rake_helpers/code.rb
+++ b/rake_helpers/code.rb
@@ -10,11 +10,11 @@ class Code
 
     def install_gems
       puts 'Installing gems'
-      Dir.chdir("#{Dir.home}/Code/Work/currica/web")
+
       #https://github.com/bundler/bundler/issues/925
       require 'bundler'
       Bundler.with_clean_env do
-        system 'bundle install'
+        system "bash --login -i -c 'rvm use #{Code.ruby_version}; cd #{Dir.home}/Code/Work/currica/web; bundle install'"
       end
       puts 'Gems installed'
     end

--- a/rake_helpers/code.rb
+++ b/rake_helpers/code.rb
@@ -6,8 +6,6 @@ class Code
       setup_git_directories
 
       system('git clone https://github.com/currica/web.git')
-
-      install_gems
     end
 
     def install_gems

--- a/rake_helpers/code.rb
+++ b/rake_helpers/code.rb
@@ -11,8 +11,14 @@ class Code
     end
 
     def install_gems
+      puts 'Installing gems'
       Dir.chdir("#{Dir.home}/Code/Work/currica/web")
-      system('bundle install')
+      #https://github.com/bundler/bundler/issues/925
+      require 'bundler'
+      Bundler.with_clean_env do
+        system 'bundle install'
+      end
+      puts 'Gems installed'
     end
 
     def ruby_version

--- a/rake_helpers/code.rb
+++ b/rake_helpers/code.rb
@@ -5,7 +5,7 @@ class Code
 
       setup_git_directories
 
-      `git clone https://github.com/currica/web.git`
+      system('git clone https://github.com/currica/web.git')
 
       install_gems
     end

--- a/rake_helpers/code.rb
+++ b/rake_helpers/code.rb
@@ -1,21 +1,23 @@
 class Code
   class << self
     def setup
-      setup_git_directories
-
       copy_gemrc
 
+      setup_git_directories
+
       `git clone https://github.com/currica/web.git`
+
+      install_gems
     end
 
     def install_gems
+      Dir.chdir("#{Dir.home}/Code/Work/currica/web")
       # Requires a change to web to work properly.
       # `bundle install`
     end
 
     def ruby_version
-      # Assuming that dotfiles and web repos live in the same directory.
-      f = IO.read(File.absolute_path('../web/.ruby-version'))
+      f = IO.read("#{Dir.home}/Code/Work/currica/web/.ruby-version")
       f.lines[0].strip()
     end
 
@@ -24,10 +26,11 @@ class Code
       `mkdir ~/Code`
       `mkdir ~/Code/Work`
       `mkdir ~/Code/Work/currica`
-      Dir.chdir("#{Dir.home}/Code/Work/currica/web")
+      Dir.chdir("#{Dir.home}/Code/Work/currica")
     end
 
     def copy_gemrc
+      # Run from the dotfiles repo
       `cp ruby/.gemrc #{Dir.home}/.gemrc`
     end
   end

--- a/rake_helpers/code.rb
+++ b/rake_helpers/code.rb
@@ -12,8 +12,7 @@ class Code
 
     def install_gems
       Dir.chdir("#{Dir.home}/Code/Work/currica/web")
-      # Requires a change to web to work properly.
-      # `bundle install`
+      system('bundle install')
     end
 
     def ruby_version

--- a/rake_helpers/homebrew.rb
+++ b/rake_helpers/homebrew.rb
@@ -40,30 +40,12 @@ class Homebrew
       puts 'Installing packages'
 
       `brew install \
-      ctags \
-      gdbm \
       git \
-      go \
-      imagemagick \
-      leiningen \
-      libelf \
-      libffi \
-      libevent \
-      libxml2 \
-      libxslt \
-      libyaml \
       memcached \
-      node \
       phantomjs \
       postgresql \
       qt \
-      reattach-to-user-namespace \
-      the_silver_searcher \
-      tmux \
-      vim \
-      wemux \
-      wget \
-      zsh
+      vim
       `
     end
   end

--- a/rake_helpers/homebrew.rb
+++ b/rake_helpers/homebrew.rb
@@ -25,7 +25,6 @@ class Homebrew
     def install
       puts 'Installing Homebrew'
 
-      # `ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"`
       system('ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"')
 
       puts 'Finished installing Homebrew.'

--- a/rake_helpers/homebrew.rb
+++ b/rake_helpers/homebrew.rb
@@ -30,6 +30,10 @@ class Homebrew
 
       puts 'Finished installing Homebrew.'
 
+      puts 'Running brew doctor'
+
+      system('brew doctor')
+
       install_packages
     end
 

--- a/rake_helpers/homebrew.rb
+++ b/rake_helpers/homebrew.rb
@@ -23,9 +23,12 @@ class Homebrew
     end
 
     def install
-      puts 'Installing homebrew'
+      puts 'Installing Homebrew'
 
-      `ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"`
+      # `ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"`
+      system('ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"')
+
+      puts 'Finished installing Homebrew.'
 
       install_packages
     end

--- a/rake_helpers/homebrew.rb
+++ b/rake_helpers/homebrew.rb
@@ -2,8 +2,6 @@ class Homebrew
   class << self
     def setup
       install_or_update_homebrew
-
-      install_packages
     end
 
     def update
@@ -21,51 +19,45 @@ class Homebrew
     end
 
     def exists?
-      `brew`.match(%r(Example usage)) ? true : false
+      system 'which brew > /dev/null'
     end
 
     def install
       puts 'Installing homebrew'
 
       `ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"`
+
+      install_packages
     end
 
     def install_packages
       puts 'Installing packages'
 
       `brew install \
-      phantomjs \
-      reattach-to-user-namespace \
-      the_silver_searcher \
-      tmux \
-      wget \
+      ctags \
+      gdbm \
       git \
-      memcached \
-      autoconf \
-      automake \
       go \
       imagemagick \
       leiningen \
       libelf \
+      libffi \
       libevent \
       libxml2 \
       libxslt \
-      openssl \
-      postgresql \
-      chruby \
-      ruby-build \
-      node \
-      zsh \
-      gdbm \
-      libffi \
-      ruby-install \
       libyaml \
-      openssl \
-      readline \
+      memcached \
+      node \
+      phantomjs \
+      postgresql \
+      qt \
+      reattach-to-user-namespace \
+      the_silver_searcher \
+      tmux \
       vim \
       wemux \
-      ctags \
-      qt
+      wget \
+      zsh
       `
     end
   end

--- a/rake_helpers/ruby.rb
+++ b/rake_helpers/ruby.rb
@@ -1,7 +1,5 @@
 class Ruby
   class << self
-    # Our philosophy is to always use the latest ruby we ensure the latest
-    # ruby is used by sourcing `chruby ruby` in our ``~/.zshrc``
     def setup
       install_rvm
 
@@ -9,20 +7,22 @@ class Ruby
 
       install_global_gems
     end
-    alias_method :update, :setup
+
+    def update
+      install_latest_ruby
+    end
 
     private
 
     def install_rvm
       puts 'installing rvm'
-      `\curl -sSL https://get.rvm.io | bash -s stable`
+      `\\curl -sSL https://get.rvm.io | bash -s stable`
       system "source #{Dir.home}/.rvm/scripts/rvm"
     end
 
     def install_latest_ruby
       puts 'installing latest ruby. WARNING this takes a while.'
-      `ruby-install --no-reinstall ruby #{Code.ruby_version}`
-
+      system "bash --login -i -c 'rvm install ruby-#{Code.ruby_version}'"
       system "bash --login -i -c 'rvm use #{Code.ruby_version}'"
     end
 

--- a/rake_helpers/ruby.rb
+++ b/rake_helpers/ruby.rb
@@ -15,9 +15,10 @@ class Ruby
     private
 
     def install_rvm
-      puts 'Installing rvm'
+      puts 'Installing RVM'
       `\\curl -sSL https://get.rvm.io | bash -s stable`
       system "source #{Dir.home}/.rvm/scripts/rvm"
+      puts 'RVM installed'
     end
 
     def install_latest_ruby

--- a/rake_helpers/ruby.rb
+++ b/rake_helpers/ruby.rb
@@ -12,6 +12,10 @@ class Ruby
       install_latest_ruby
     end
 
+    def rvm_warning
+      puts "Please run 'rvm use ruby-#{Code.ruby_version}' in your console to complete installation."
+    end
+
     private
 
     def install_rvm
@@ -24,7 +28,6 @@ class Ruby
     def install_latest_ruby
       puts 'Installing latest ruby. WARNING this takes a while.'
       system "bash --login -i -c 'rvm install ruby-#{Code.ruby_version}'"
-      system "bash --login -i -c 'rvm use #{Code.ruby_version}'"
     end
 
     def use_latest_ruby

--- a/rake_helpers/ruby.rb
+++ b/rake_helpers/ruby.rb
@@ -15,13 +15,13 @@ class Ruby
     private
 
     def install_rvm
-      puts 'installing rvm'
+      puts 'Installing rvm'
       `\\curl -sSL https://get.rvm.io | bash -s stable`
       system "source #{Dir.home}/.rvm/scripts/rvm"
     end
 
     def install_latest_ruby
-      puts 'installing latest ruby. WARNING this takes a while.'
+      puts 'Installing latest ruby. WARNING this takes a while.'
       system "bash --login -i -c 'rvm install ruby-#{Code.ruby_version}'"
       system "bash --login -i -c 'rvm use #{Code.ruby_version}'"
     end
@@ -31,7 +31,7 @@ class Ruby
     end
 
     def install_global_gems
-      puts 'installing global gems'
+      puts 'Installing global gems'
 
       `gem install bundler \
         gem-ctags \

--- a/rake_helpers/ruby.rb
+++ b/rake_helpers/ruby.rb
@@ -13,7 +13,7 @@ class Ruby
     end
 
     def rvm_warning
-      puts "Please run 'rvm use ruby-#{Code.ruby_version}' in your console to complete installation."
+      puts "Please run 'source ~/.profile' in your console to complete installation."
     end
 
     private

--- a/rake_helpers/ruby.rb
+++ b/rake_helpers/ruby.rb
@@ -37,7 +37,7 @@ class Ruby
     def install_bundler
       puts 'Installing bundler'
 
-      system "bash --login -i -c 'rvm use #{Code.ruby_version}; rvm @global do gem install bundler'"
+      system('gem install bundler')
     end
   end
 end

--- a/rake_helpers/ruby.rb
+++ b/rake_helpers/ruby.rb
@@ -5,7 +5,7 @@ class Ruby
 
       install_latest_ruby
 
-      install_global_gems
+      install_bundler
     end
 
     def update
@@ -34,15 +34,10 @@ class Ruby
       puts 'using the latest ruby'
     end
 
-    def install_global_gems
-      puts 'Installing global gems'
+    def install_bundler
+      puts 'Installing bundler'
 
-      `gem install bundler \
-        gem-ctags \
-        rubygems-bundler \
-        rake \
-        byebug \
-        tmuxinator`
+      system "bash --login -i -c 'rvm use #{Code.ruby_version}; rvm @global do gem install bundler'"
     end
   end
 end


### PR DESCRIPTION
I decided to make the `dotfiles:bootstrap` task be simply about setting up the base libraries, code, and gems required to get started with development. I've created two new tasks, `dotfiles:symlinks` and `dotfiles:plugins` for the "non-essential" portions, like installing zsh or vundle. 

I've tested this a bunch on a Mac VM I created, and it should work on a fresh machine. The main issue I ran into was installing the global gems, but I think that's from permissions issues on the VM (I hope). 